### PR TITLE
Delete 2011 06 18

### DIFF
--- a/txredis/protocol.py
+++ b/txredis/protocol.py
@@ -503,11 +503,11 @@ class Redis(RedisBase):
         self._send('EXISTS', key)
         return self.getResponse()
 
-    def delete(self, key):
+    def delete(self, key, *keys):
         """
-        Delete a key
+        Delete one or more keys
         """
-        self._send('DEL', key)
+        self._send('DEL', key, *keys)
         return self.getResponse()
 
     def get_type(self, key):

--- a/txredis/test/test_redis.py
+++ b/txredis/test/test_redis.py
@@ -118,6 +118,15 @@ class General(CommandsTestBase):
         a = yield r.delete('a')
         ex = 0
         t(a, ex)
+        a = yield r.set('a', 'a')
+        ex = 'OK'
+        t(a, ex)
+        a = yield r.set('b', 'b')
+        ex = 'OK'
+        t(a, ex)
+        a = yield r.delete('a', 'b')
+        ex = 2
+        t(a, ex)
 
     @defer.inlineCallbacks
     def test_get_type(self):


### PR DESCRIPTION
Allow delete() to accept one or more keys, like the redis command.
