### PR TITLE
Remove unnecessary use of defer.inlineCallbacks in pubsub example

### DIFF
--- a/examples/pubsub.py
+++ b/examples/pubsub.py
@@ -8,17 +8,13 @@ import sys
 REDIS_HOST = 'localhost'
 REDIS_PORT = 6379
 
-@defer.inlineCallbacks
 def getRedisSubscriber():
     clientCreator = protocol.ClientCreator(reactor, RedisSubscriber)
-    redis = yield clientCreator.connectTCP(REDIS_HOST, REDIS_PORT)
-    defer.returnValue(redis)
+    return clientCreator.connectTCP(REDIS_HOST, REDIS_PORT)
 
-@defer.inlineCallbacks
 def getRedis():
     clientCreator = protocol.ClientCreator(reactor, Redis)
-    redis = yield clientCreator.connectTCP(REDIS_HOST, REDIS_PORT)
-    defer.returnValue(redis)
+    return clientCreator.connectTCP(REDIS_HOST, REDIS_PORT)
 
 @defer.inlineCallbacks
 def runTest():


### PR DESCRIPTION
A couple of the utility functions were decorated with defer.inlineCallbacks, and yielded deferreds whose results neither of them actually cared about - the functions can just return the deferreds directly.
