### PR TITLE
Remove redundant "ERR" from ResponseError message

### DIFF
--- a/txredis/protocol.py
+++ b/txredis/protocol.py
@@ -185,7 +185,7 @@ class RedisBase(protocol.Protocol, policies.TimeoutMixin, object):
     def errorReceived(self, data):
         """Error response received."""
         reply = exceptions.ResponseError(
-            data if data[:4] == 'ERR ' else data)
+            data[4:] if data[:4] == 'ERR ' else data)
         if self._request_queue:
             # properly errback this reply
             self._request_queue.popleft().errback(reply)

--- a/txredis/tests/test_client.py
+++ b/txredis/tests/test_client.py
@@ -180,7 +180,7 @@ class GeneralCommandTestCase(CommandsBaseTestCase):
         d = r.rename('a', 'a')
         self.failUnlessFailure(d, ResponseError)
         def test_err(a):
-            ex = ResponseError('ERR source and destination objects are the same')
+            ex = ResponseError('source and destination objects are the same')
             t(str(a), str(ex))
         d.addCallback(test_err)
         return d
@@ -859,7 +859,7 @@ class ListsCommandsTestCase(CommandsBaseTestCase):
             d = r.lset('l', 0, 'a')
             self.failUnlessFailure(d, ResponseError)
             def match_err(a):
-                ex = ResponseError('ERR no such key')
+                ex = ResponseError('no such key')
                 t(str(a), str(ex))
             d.addCallback(match_err)
             return d
@@ -879,7 +879,7 @@ class ListsCommandsTestCase(CommandsBaseTestCase):
                 d = r.lset('l', 1, 'a')
                 self.failUnlessFailure(d, ResponseError)
                 def check(a):
-                    ex = ResponseError('ERR index out of range')
+                    ex = ResponseError('index out of range')
                     t(str(a), str(ex))
                 d.addCallback(check)
                 return d


### PR DESCRIPTION
A tiny patch, but it seems like the original intent was to remove "ERR" from the ResponseError string since this is redundant. Removing ERR in the message is also done in redis-py. The current code is at least peculiar enough to suggest this:

ResponseError(data if data[:4] == 'ERR ' or data) # ??? of course, always data no matter what
