### PR TITLE
Remove unneeded setting of noisy in __init__() of RedisClientFactory

### DIFF
--- a/txredis/client.py
+++ b/txredis/client.py
@@ -1583,7 +1583,6 @@ class RedisClientFactory(ReconnectingClientFactory):
     protocol = RedisClient
 
     def __init__(self, *args, **kwargs):
-        self.noisy = True
         self._args = args
         self._kwargs = kwargs
         self.client = None


### PR DESCRIPTION
RedisClientFactory inherits from ReconnectingClientFactory which is set to noisy
by default.
